### PR TITLE
bump golang to 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - "1.10"
-  - master
+  - "1.12"
 
 install:
   - make dep


### PR DESCRIPTION
This PR bumps golang used in travis CI to 1.12.